### PR TITLE
Added `exports.default`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "exports": {
     ".": {
       "import": "./dist/index.jsx",
+      "default": "./dist/index.jsx",
       "types": "./dist/index.d.ts"
     }
   },


### PR DESCRIPTION
When a package defines an "exports" map, Node/Webpack/Next.js will only allow the conditions explicitly listed there. The current @overengineering/fps-meter package.json only specifies:
```
"exports": {
  ".": {
    "import": "./dist/index.jsx",
    "types": "./dist/index.d.ts"
  }
}
```

This works for pure ESM import consumers, but breaks any environment that resolves with the require or default condition, for example Next.js SSR, Jest, or Webpack in mixed-module mode. Those code paths end up with:
```
 Package path . is not exported from package ./node_modules/@overengineering/fps-meter (see exports field in ./node_modules/@overengineering/fps-meter/package.json)
```